### PR TITLE
Hide "Powered by CILogon" icon/link.

### DIFF
--- a/src/rubin.css
+++ b/src/rubin.css
@@ -202,3 +202,10 @@ div.skincilogonlogo {
 div.form-check {
   display: none;
 }
+
+/*
+ * Hide the "Powered by CILogon" icon/link in the upper-right corner.
+ */
+div.skincilogonlogo {
+  display: none;
+}


### PR DESCRIPTION
As discussed at a meeting between Russ Allbery, Rossie Economou, and Jim Basney on 2023-01-10, hide the "Powered by CILogon" icon in the upper-right corner of the CILogon "Select an Identity Provider" page. This update has been deployed to:

- https://cilogon.org/?skin=lsst 
- https://test.cilogon.org/?skin=lsst 
- https://dev.cilogon.org/?skin=lsst 